### PR TITLE
Correct typo in method name: setThreshholds

### DIFF
--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -71,6 +71,11 @@ boolean Adafruit_MPR121::begin(uint8_t i2caddr) {
 }
 
 void Adafruit_MPR121::setThreshholds(uint8_t touch, uint8_t release) {
+
+  setThresholds(touch, release);
+  }
+
+void Adafruit_MPR121::setThresholds(uint8_t touch, uint8_t release) {
   for (uint8_t i=0; i<12; i++) {
     writeRegister(MPR121_TOUCHTH_0 + 2*i, touch);
     writeRegister(MPR121_RELEASETH_0 + 2*i, release);

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -80,7 +80,9 @@ class Adafruit_MPR121 {
   uint16_t readRegister16(uint8_t reg);
   void writeRegister(uint8_t reg, uint8_t value);
   uint16_t touched(void);
-  void setThreshholds(uint8_t touch, uint8_t release);
+  // Add deprecated attribute so that the compiler shows a warning
+  __attribute__((deprecated)) void setThreshholds(uint8_t touch, uint8_t release);
+  void setThresholds(uint8_t touch, uint8_t release);
 
  private:
   int8_t _i2caddr;


### PR DESCRIPTION
Not a massive issue, but confused me for a while so I have renamed setThreshholds to setThresholds but kept the original method there to maintain backwards compatibility.