### PR TITLE
Add Header Guards

### DIFF
--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -14,6 +14,9 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
+#ifndef ADAFRUIT_MPR121_H
+#define ADAFRUIT_MPR121_H
+ 
 #if (ARDUINO >= 100)
  #include "Arduino.h"
 #else
@@ -86,3 +89,4 @@ class Adafruit_MPR121 {
   int8_t _i2caddr;
 };
 
+#endif // ADAFRUIT_MPR121_H


### PR DESCRIPTION
Had an issue with a project of mine that used several libraries that relied on the MPR121 library, so I added the header guards to allow the MPR121 library to be included by  several libraries without a problem