### PR TITLE
Add keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,6 @@
+Adafruit_MPR121	KEYWORD1
+begin	KEYWORD2
+filteredData	KEYWORD2
+baselineData	KEYWORD2
+touched	KEYWORD2
+setThresholds	KEYWORD2


### PR DESCRIPTION
Added this so that highlighting in the Arduino IDE would work. I have ignored readRegister8/16 and writeRegister as I can't imagine many users would use those directly. I've also used the corrected spelling of setThresholds so maybe this should only be accepted after #1 